### PR TITLE
iOS 26, iPadOS 26対応の取り込み

### DIFF
--- a/Examples/RefresherTest.xcodeproj/project.pbxproj
+++ b/Examples/RefresherTest.xcodeproj/project.pbxproj
@@ -16,31 +16,12 @@
 		D3A3F333280F186C00BB28F1 /* Refresher in Frameworks */ = {isa = PBXBuildFile; productRef = D3A3F332280F186C00BB28F1 /* Refresher */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		D3A3F2EF280CBFEF00BB28F1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D3A3F2D5280CBFEE00BB28F1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D3A3F2E0280CBFEF00BB28F1;
-			remoteInfo = "RefresherTest (iOS)";
-		};
-		D3A3F2FB280CBFEF00BB28F1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D3A3F2D5280CBFEE00BB28F1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D3A3F2E6280CBFEF00BB28F1;
-			remoteInfo = "RefresherTest (macOS)";
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
 		D3A3F2DA280CBFEE00BB28F1 /* RefresherTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefresherTestApp.swift; sourceTree = "<group>"; };
 		D3A3F2DB280CBFEE00BB28F1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D3A3F2DC280CBFEF00BB28F1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D3A3F2E1280CBFEF00BB28F1 /* RefresherTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RefresherTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3A3F2E7280CBFEF00BB28F1 /* RefresherTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RefresherTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D3A3F2EE280CBFEF00BB28F1 /* Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D3A3F2FA280CBFEF00BB28F1 /* Tests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3A3F331280F185E00BB28F1 /* Refresher */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Refresher; path = ..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -54,20 +35,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D3A3F2E4280CBFEF00BB28F1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3A3F2EB280CBFEF00BB28F1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3A3F2F7280CBFEF00BB28F1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -95,8 +62,6 @@
 			children = (
 				D3A3F2E1280CBFEF00BB28F1 /* RefresherTest.app */,
 				D3A3F2E7280CBFEF00BB28F1 /* RefresherTest.app */,
-				D3A3F2EE280CBFEF00BB28F1 /* Tests iOS.xctest */,
-				D3A3F2FA280CBFEF00BB28F1 /* Tests macOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -155,42 +120,6 @@
 			productReference = D3A3F2E7280CBFEF00BB28F1 /* RefresherTest.app */;
 			productType = "com.apple.product-type.application";
 		};
-		D3A3F2ED280CBFEF00BB28F1 /* Tests iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D3A3F310280CBFEF00BB28F1 /* Build configuration list for PBXNativeTarget "Tests iOS" */;
-			buildPhases = (
-				D3A3F2EA280CBFEF00BB28F1 /* Sources */,
-				D3A3F2EB280CBFEF00BB28F1 /* Frameworks */,
-				D3A3F2EC280CBFEF00BB28F1 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D3A3F2F0280CBFEF00BB28F1 /* PBXTargetDependency */,
-			);
-			name = "Tests iOS";
-			productName = "Tests iOS";
-			productReference = D3A3F2EE280CBFEF00BB28F1 /* Tests iOS.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
-		};
-		D3A3F2F9280CBFEF00BB28F1 /* Tests macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D3A3F313280CBFEF00BB28F1 /* Build configuration list for PBXNativeTarget "Tests macOS" */;
-			buildPhases = (
-				D3A3F2F6280CBFEF00BB28F1 /* Sources */,
-				D3A3F2F7280CBFEF00BB28F1 /* Frameworks */,
-				D3A3F2F8280CBFEF00BB28F1 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D3A3F2FC280CBFEF00BB28F1 /* PBXTargetDependency */,
-			);
-			name = "Tests macOS";
-			productName = "Tests macOS";
-			productReference = D3A3F2FA280CBFEF00BB28F1 /* Tests macOS.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -206,14 +135,6 @@
 					};
 					D3A3F2E6280CBFEF00BB28F1 = {
 						CreatedOnToolsVersion = 13.3.1;
-					};
-					D3A3F2ED280CBFEF00BB28F1 = {
-						CreatedOnToolsVersion = 13.3.1;
-						TestTargetID = D3A3F2E0280CBFEF00BB28F1;
-					};
-					D3A3F2F9280CBFEF00BB28F1 = {
-						CreatedOnToolsVersion = 13.3.1;
-						TestTargetID = D3A3F2E6280CBFEF00BB28F1;
 					};
 				};
 			};
@@ -232,8 +153,6 @@
 			targets = (
 				D3A3F2E0280CBFEF00BB28F1 /* RefresherTest (iOS) */,
 				D3A3F2E6280CBFEF00BB28F1 /* RefresherTest (macOS) */,
-				D3A3F2ED280CBFEF00BB28F1 /* Tests iOS */,
-				D3A3F2F9280CBFEF00BB28F1 /* Tests macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -252,20 +171,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3A3F307280CBFEF00BB28F1 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3A3F2EC280CBFEF00BB28F1 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3A3F2F8280CBFEF00BB28F1 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,34 +195,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D3A3F2EA280CBFEF00BB28F1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3A3F2F6280CBFEF00BB28F1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		D3A3F2F0280CBFEF00BB28F1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D3A3F2E0280CBFEF00BB28F1 /* RefresherTest (iOS) */;
-			targetProxy = D3A3F2EF280CBFEF00BB28F1 /* PBXContainerItemProxy */;
-		};
-		D3A3F2FC280CBFEF00BB28F1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D3A3F2E6280CBFEF00BB28F1 /* RefresherTest (macOS) */;
-			targetProxy = D3A3F2FB280CBFEF00BB28F1 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		D3A3F308280CBFEF00BB28F1 /* Debug */ = {
@@ -546,85 +424,6 @@
 			};
 			name = Release;
 		};
-		D3A3F311280CBFEF00BB28F1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 79TGW25V5A;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "bugtest.Tests-iOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "RefresherTest (iOS)";
-			};
-			name = Debug;
-		};
-		D3A3F312280CBFEF00BB28F1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 79TGW25V5A;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "bugtest.Tests-iOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "RefresherTest (iOS)";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		D3A3F314280CBFEF00BB28F1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 79TGW25V5A;
-				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "bugtest.Tests-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TEST_TARGET_NAME = "RefresherTest (macOS)";
-			};
-			name = Debug;
-		};
-		D3A3F315280CBFEF00BB28F1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 79TGW25V5A;
-				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "bugtest.Tests-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TEST_TARGET_NAME = "RefresherTest (macOS)";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -651,24 +450,6 @@
 			buildConfigurations = (
 				D3A3F30E280CBFEF00BB28F1 /* Debug */,
 				D3A3F30F280CBFEF00BB28F1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D3A3F310280CBFEF00BB28F1 /* Build configuration list for PBXNativeTarget "Tests iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D3A3F311280CBFEF00BB28F1 /* Debug */,
-				D3A3F312280CBFEF00BB28F1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D3A3F313280CBFEF00BB28F1 /* Build configuration list for PBXNativeTarget "Tests macOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D3A3F314280CBFEF00BB28F1 /* Debug */,
-				D3A3F315280CBFEF00BB28F1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/RefresherTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/RefresherTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
-        "revision" : "668a65735751432b640260c56dfa621cec568368",
-        "version" : "1.2.0"
+        "revision" : "d2987affc5482a94d94aa730914aa26b124648a6",
+        "version" : "1.4.0-beta.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
-        "revision" : "668a65735751432b640260c56dfa621cec568368",
-        "version" : "1.2.0"
+        "revision" : "c2b0625d0ef385994e4c6bc36116c0e7bfa6dafa",
+        "version" : "1.4.0-beta.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "1.2.0"),
+        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "1.4.0-beta.2"),
         .package(url: "https://github.com/gh123man/SwiftUI-RenderLock", from: "1.0.2"),
     ],
     targets: [

--- a/Sources/Refresher/Refresher.swift
+++ b/Sources/Refresher/Refresher.swift
@@ -253,7 +253,7 @@ public struct RefreshableScrollView<Content: View, RefreshView: View>: View {
                 system3StyleRefreshSpinner
                     .frame(height: system3SpinnerHeight)
             }, alignment: .top)
-            .introspect(.scrollView, on: .iOS(.v14, .v15, .v16, .v17, .v18)) { scrollView in
+            .introspect(.scrollView, on: .iOS(.v14, .v15, .v16, .v17, .v18, .v26)) { scrollView in
                 DispatchQueue.main.async {
                     uiScrollView = scrollView
                 }


### PR DESCRIPTION
## やったこと
- fork元がiOS 26, iPadOS 26対応をしたので、その取り込み

## 備考
- mainはfork元を更新して追っていく前提なので、 `patch-custom-refresh` をmerge先に指定